### PR TITLE
Update confirmation message page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meu Sistema</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at center, #f5f5f5, #d9e2ec);
+      }
+
+      .message {
+        padding: 2rem 3rem;
+        border-radius: 1rem;
+        background-color: rgba(255, 255, 255, 0.85);
+        box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.15);
+        text-align: center;
+        font-size: clamp(1.5rem, 4vw, 2.5rem);
+        font-weight: 600;
+        color: #0f172a;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="message">agora sim tá autorizado</div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple web page that displays "agora sim tá autorizado" centered on screen
- include responsive styling to keep the confirmation message prominent

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1d37ea1e8832aab43229420aae6ec